### PR TITLE
Fix output WAV file structure

### DIFF
--- a/makewav.js
+++ b/makewav.js
@@ -68,8 +68,8 @@ Wav.prototype.getWavUint8Array = function(buffer){
     intBuffer[0] = 0x4952; // "RI"
     intBuffer[1] = 0x4646; // "FF"
 
-    intBuffer[2] = (buffer.length + WAV_HEADER_SIZE - 8) & 0x0000ffff; // RIFF size
-    intBuffer[3] = ((buffer.length + WAV_HEADER_SIZE - 8) & 0xffff0000) >> 16; // RIFF size
+    intBuffer[2] = (buffer.length + WAV_HEADER_SIZE * 2 - 8) & 0x0000ffff; // RIFF size
+    intBuffer[3] = ((buffer.length + WAV_HEADER_SIZE * 2 - 8) & 0xffff0000) >> 16; // RIFF size
 
     intBuffer[4] = 0x4157; // "WA"
     intBuffer[5] = 0x4556; // "VE"

--- a/tape.js
+++ b/tape.js
@@ -146,7 +146,7 @@ TapeFormat.prototype.makewav = function()
     var params = {sampleRate:22050, channels: 1};
     wav = new Wav(params);
     wav.setBuffer(encoded);
-    var stream = wav.getBuffer(encoded.length);
+    var stream = wav.getBuffer(encoded.length + WAV_HEADER_SIZE * 2);
     return stream;
 }
 


### PR DESCRIPTION
Data size field in the RIFF header was erroneous, the last few samples were absent from the entire wav file.